### PR TITLE
Add an instance for Basis[CoattrF[F, A, ?], Free[F, A]]

### DIFF
--- a/modules/core/src/main/scala/qq/droste/basis.scala
+++ b/modules/core/src/main/scala/qq/droste/basis.scala
@@ -149,8 +149,12 @@ private[droste] sealed trait FloatingBasisInstances0[H[F[_], A] >: Basis[F, A]] 
     CoattrF[F, A, ?],
     cats.free.Free[F, A]] =
     Basis.Default[CoattrF[F, A, ?], cats.free.Free[F, A]](
-      Algebra { CoattrF.un(_).fold(cats.free.Free.pure, cats.free.Free.roll) },
-      Coalgebra { _.fold[CoattrF[F, A, cats.free.Free[F,A]]](CoattrF.pure, CoattrF.roll) }
+      Algebra {
+        CoattrF.un(_).fold(cats.free.Free.pure, cats.free.Free.roll)
+      },
+      Coalgebra {
+        _.fold[CoattrF[F, A, cats.free.Free[F, A]]](CoattrF.pure, CoattrF.roll)
+      }
     )
 }
 

--- a/modules/core/src/main/scala/qq/droste/basis.scala
+++ b/modules/core/src/main/scala/qq/droste/basis.scala
@@ -12,6 +12,7 @@ import util.newtypes._
 import cats.Eval
 import cats.Eq
 import cats.Foldable
+import cats.Functor
 import cats.Monad
 import cats.Monoid
 import cats.free.Trampoline
@@ -143,6 +144,14 @@ private[droste] sealed trait FloatingBasisInstances0[H[F[_], A] >: Basis[F, A]] 
     Basis.Default[AttrF[F, A, ?], cats.free.Cofree[F, A]](
       Algebra(fa => cats.free.Cofree(fa.ask, Eval.now(fa.lower))),
       Coalgebra(a => AttrF(a.head, a.tailForced)))
+
+  implicit def drosteBasisForCatsFree[F[_]: Functor, A]: H[
+    CoattrF[F, A, ?],
+    cats.free.Free[F, A]] =
+    Basis.Default[CoattrF[F, A, ?], cats.free.Free[F, A]](
+      Algebra { CoattrF.un(_).fold(cats.free.Free.pure, cats.free.Free.roll) },
+      Coalgebra { _.fold[CoattrF[F, A, cats.free.Free[F,A]]](CoattrF.pure, CoattrF.roll) }
+    )
 }
 
 private[droste] sealed trait FloatingBasisSolveInstances {
@@ -154,5 +163,10 @@ private[droste] sealed trait FloatingBasisSolveInstances {
   implicit def drosteSolveCatsCofree[A]: Solve.Aux[
     cats.free.Cofree[?[_], A],
     AttrF[?[_], A, ?]] =
+    null
+
+  implicit def drosteSolveCatsFree[A]: Solve.Aux[
+    cats.free.Free[?[_], A],
+    CoattrF[?[_], A, ?]] =
     null
 }

--- a/modules/core/src/main/scala/qq/droste/data/Coattr.scala
+++ b/modules/core/src/main/scala/qq/droste/data/Coattr.scala
@@ -1,6 +1,9 @@
 package qq.droste
 package data
 
+import cats.Functor
+import cats.syntax.functor._
+
 import meta.Meta
 
 object Coattr {
@@ -17,6 +20,11 @@ object Coattr {
 
   def coalgebra[F[_], A]: Coalgebra[CoattrF[F, A, ?], Coattr[F, A]] =
     Coalgebra(a => CoattrF(Coattr.un(a)))
+
+  def fromCats[F[_]: Functor, A](free: cats.free.Free[F, A]): Coattr[F, A] =
+    free.fold(pure, { ffree =>
+      roll(ffree.map(fromCats(_)))
+    })
 
   object Pure {
     def unapply[F[_], A](f: Coattr[F, A]): Option[A] = un(f) match {
@@ -38,5 +46,10 @@ trait CoattrImplicits {
   implicit final class CoattrOps[F[_], A](coattr: Coattr[F, A]) {
     def fold[B](f: A => B, fffa: F[Coattr[F, A]] => B): B =
       Coattr.un(coattr).fold(f, fffa)
+
+    def toCats(implicit ev: Functor[F]): cats.free.Free[F, A] =
+      fold(cats.free.Free.pure, { fcoattr =>
+        cats.free.Free.roll(fcoattr.map(_.toCats))
+      })
   }
 }

--- a/modules/core/src/main/scala/qq/droste/data/CoattrF.scala
+++ b/modules/core/src/main/scala/qq/droste/data/CoattrF.scala
@@ -50,9 +50,9 @@ private[data] sealed trait CoenvtTImplicits0 {
     new Delay[Eq, CoattrF[F, A, ?]] {
       def apply[B](eqb: Eq[B]): Eq[CoattrF[F, A, B]] = Eq.instance { (x, y) =>
         (CoattrF.un(x), CoattrF.un(y)) match {
-          case (Left(xx), Left(yy)) => eqa.eqv(xx, yy)
+          case (Left(xx), Left(yy))   => eqa.eqv(xx, yy)
           case (Right(xx), Right(yy)) => deqf(eqb).eqv(xx, yy)
-          case _ => false
+          case _                      => false
         }
       }
     }

--- a/modules/scalacheck/src/main/scala/qq/droste/scalacheck/package.scala
+++ b/modules/scalacheck/src/main/scala/qq/droste/scalacheck/package.scala
@@ -81,10 +81,22 @@ object `package` {
     Gen.sized(maxSize =>
       scheme[Nu].anaM(CoalgebraM(genSizedF[F])).apply(maxSize))
 
+
+  implicit def drosteArbitraryCofree[F[_]: Applicative: MonoidK, A: Arbitrary](
+      implicit ev: Traverse[AttrF[F, A, ?]]
+  ): Arbitrary[cats.free.Cofree[F, A]] =
+    Arbitrary(drosteGenAttr[F, A].map(_.toCats))
+
   implicit def drosteArbitraryAttr[F[_]: Applicative: MonoidK, A: Arbitrary](
       implicit ev: Traverse[AttrF[F, A, ?]]
   ): Arbitrary[Attr[F, A]] =
     Arbitrary(drosteGenAttr)
+
+
+  implicit def drosteArbitraryFree[F[_]: Applicative: MonoidK, A: Arbitrary](
+      implicit ev: Traverse[F]
+  ): Arbitrary[cats.free.Free[F, A]] =
+    Arbitrary(drosteGenCoattr[F, A].map(_.toCats(ev)))
 
   implicit def drosteArbitraryCoattr[F[_]: Applicative: MonoidK, A: Arbitrary](
       implicit ev: Traverse[F]

--- a/modules/scalacheck/src/main/scala/qq/droste/scalacheck/package.scala
+++ b/modules/scalacheck/src/main/scala/qq/droste/scalacheck/package.scala
@@ -81,7 +81,6 @@ object `package` {
     Gen.sized(maxSize =>
       scheme[Nu].anaM(CoalgebraM(genSizedF[F])).apply(maxSize))
 
-
   implicit def drosteArbitraryCofree[F[_]: Applicative: MonoidK, A: Arbitrary](
       implicit ev: Traverse[AttrF[F, A, ?]]
   ): Arbitrary[cats.free.Cofree[F, A]] =
@@ -91,7 +90,6 @@ object `package` {
       implicit ev: Traverse[AttrF[F, A, ?]]
   ): Arbitrary[Attr[F, A]] =
     Arbitrary(drosteGenAttr)
-
 
   implicit def drosteArbitraryFree[F[_]: Applicative: MonoidK, A: Arbitrary](
       implicit ev: Traverse[F]

--- a/modules/tests/src/test/scala/qq/droste/tests/CofreeTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/CofreeTests.scala
@@ -1,0 +1,22 @@
+package qq.droste
+package tests
+
+import prelude._
+import data.prelude._
+import data.AttrF
+
+import cats.free.Cofree
+import cats.implicits._
+
+import laws.BasisLaws
+import scalacheck._
+
+import org.scalacheck.Properties
+
+
+final class CofreeTests extends Properties("Cofree") {
+
+  include(BasisLaws.props[AttrF[Option, Int, ?], Cofree[Option, Int]](
+    "AttrF[Option, Int, ?]",
+    "Cofree[Option, Int]"))
+}

--- a/modules/tests/src/test/scala/qq/droste/tests/CofreeTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/CofreeTests.scala
@@ -13,10 +13,10 @@ import scalacheck._
 
 import org.scalacheck.Properties
 
-
 final class CofreeTests extends Properties("Cofree") {
 
-  include(BasisLaws.props[AttrF[Option, Int, ?], Cofree[Option, Int]](
-    "AttrF[Option, Int, ?]",
-    "Cofree[Option, Int]"))
+  include(
+    BasisLaws.props[AttrF[Option, Int, ?], Cofree[Option, Int]](
+      "AttrF[Option, Int, ?]",
+      "Cofree[Option, Int]"))
 }

--- a/modules/tests/src/test/scala/qq/droste/tests/FreeTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/FreeTests.scala
@@ -13,11 +13,11 @@ import scalacheck._
 
 import org.scalacheck.Properties
 
-
 final class FreeTests extends Properties("Free") {
 
-  include(BasisLaws.props[CoattrF[Option, Int, ?], Free[Option, Int]](
-    "CoattrF[Option, Int, ?]",
-    "Free[Option, Int]"))
+  include(
+    BasisLaws.props[CoattrF[Option, Int, ?], Free[Option, Int]](
+      "CoattrF[Option, Int, ?]",
+      "Free[Option, Int]"))
 
 }

--- a/modules/tests/src/test/scala/qq/droste/tests/FreeTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/FreeTests.scala
@@ -1,0 +1,23 @@
+package qq.droste
+package tests
+
+import prelude._
+import data.prelude._
+import data.CoattrF
+
+import cats.free.Free
+import cats.implicits._
+
+import laws.BasisLaws
+import scalacheck._
+
+import org.scalacheck.Properties
+
+
+final class FreeTests extends Properties("Free") {
+
+  include(BasisLaws.props[CoattrF[Option, Int, ?], Free[Option, Int]](
+    "CoattrF[Option, Int, ?]",
+    "Free[Option, Int]"))
+
+}

--- a/modules/tests/src/test/scala/qq/droste/tests/SchemePartialBasisTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/SchemePartialBasisTests.scala
@@ -13,11 +13,11 @@ import eu.timepit.refined.scalacheck.numeric._
 import cats.Eval
 import cats.instances.option._
 import cats.syntax.eq._
-
 import prelude._
 import data.prelude._
 import data.Attr
 import data.CoattrF
+import data.Coattr
 import data.Fix
 import data.Mu
 import data.Nu
@@ -82,7 +82,7 @@ class SchemePartialBasisTests extends Properties("SchemePartialBasis") {
       else
         cats.free.Free.pure(n)
 
-    forAll((n: Int Refined Less[W.`100`.T]) => f(n) ?= expected(n))
+    forAll((n: Int Refined Less[W.`100`.T]) => Coattr.fromCats(f(n)) ?= Coattr.fromCats(expected(n)))
   }
 
   property("scheme[Mu].ana") = {

--- a/modules/tests/src/test/scala/qq/droste/tests/SchemePartialBasisTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/SchemePartialBasisTests.scala
@@ -72,9 +72,11 @@ class SchemePartialBasisTests extends Properties("SchemePartialBasis") {
 
   property("scheme[cats.free.Free[?[_], Int]].ana") = {
 
-    val f = scheme[cats.free.Free[?[_], Int]].ana(Coalgebra((n: Int) =>
-      if (n > 0) CoattrF.roll[Option, Int, Int](Some(n - 1))
-      else CoattrF.pure[Option, Int, Int](n)))
+    val f = scheme[cats.free.Free[?[_], Int]].ana(
+      Coalgebra(
+        (n: Int) =>
+          if (n > 0) CoattrF.roll[Option, Int, Int](Some(n - 1))
+          else CoattrF.pure[Option, Int, Int](n)))
 
     def expected(n: Int): cats.free.Free[Option, Int] =
       if (n > 0)
@@ -82,7 +84,8 @@ class SchemePartialBasisTests extends Properties("SchemePartialBasis") {
       else
         cats.free.Free.pure(n)
 
-    forAll((n: Int Refined Less[W.`100`.T]) => Coattr.fromCats(f(n)) ?= Coattr.fromCats(expected(n)))
+    forAll((n: Int Refined Less[W.`100`.T]) =>
+      Coattr.fromCats(f(n)) ?= Coattr.fromCats(expected(n)))
   }
 
   property("scheme[Mu].ana") = {

--- a/modules/tests/src/test/scala/qq/droste/tests/SchemePartialBasisTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/SchemePartialBasisTests.scala
@@ -17,6 +17,7 @@ import cats.syntax.eq._
 import prelude._
 import data.prelude._
 import data.Attr
+import data.CoattrF
 import data.Fix
 import data.Mu
 import data.Nu
@@ -65,6 +66,21 @@ class SchemePartialBasisTests extends Properties("SchemePartialBasis") {
       else
         cats.free
           .Cofree(n, Eval.now(None: Option[cats.free.Cofree[Option, Int]]))
+
+    forAll((n: Int Refined Less[W.`100`.T]) => f(n) ?= expected(n))
+  }
+
+  property("scheme[cats.free.Free[?[_], Int]].ana") = {
+
+    val f = scheme[cats.free.Free[?[_], Int]].ana(Coalgebra((n: Int) =>
+      if (n > 0) CoattrF.roll[Option, Int, Int](Some(n - 1))
+      else CoattrF.pure[Option, Int, Int](n)))
+
+    def expected(n: Int): cats.free.Free[Option, Int] =
+      if (n > 0)
+        cats.free.Free.roll(Some(expected(n - 1)))
+      else
+        cats.free.Free.pure(n)
 
     forAll((n: Int Refined Less[W.`100`.T]) => f(n) ?= expected(n))
   }


### PR DESCRIPTION
Fixes #102 

This adds the instance for `Basis[CoattrF[F, A, ?], Free[F, A]]` along with the corresponding infra needed for testing. 

I've included tests for the Basis laws for Free as well as Cofree.