### PR TITLE
Integrate with Cats-FunctionK

### DIFF
--- a/modules/core/src/main/scala/higherkindness/droste/data/Mu.scala
+++ b/modules/core/src/main/scala/higherkindness/droste/data/Mu.scala
@@ -13,12 +13,7 @@ import cats.syntax.functor._
   * In Haskell this can more aptly be expressed as:
   * `data Mu f = Mu (forall x . (f x -> x) -> x)`
   */
-sealed abstract class Mu[F[_]] extends Serializable {
-  def apply[A](fold: Algebra[F, A]): A
-
-  def toFunctionK: Algebra[F, ?] ~> Id =
-    λ[Algebra[F, ?] ~> Id](Mu.this.apply(_))
-}
+sealed abstract class Mu[F[_]] extends (Algebra[F, ?] ~> Id)
 
 object Mu {
   def algebra[F[_]: Functor]: Algebra[F, Mu[F]] =

--- a/modules/core/src/main/scala/higherkindness/droste/package.scala
+++ b/modules/core/src/main/scala/higherkindness/droste/package.scala
@@ -37,6 +37,8 @@ object `package` {
 
   object AlgebraM {
     def apply[M[_], F[_], A](f: F[A] => M[A]): AlgebraM[M, F, A] = GAlgebraM(f)
+
+    def apply[M[_], F[_], A](nt: F ~> M): AlgebraM[M, F, A] = GAlgebraM((fa: F[A]) => nt(fa))
   }
 
   object CoalgebraM {


### PR DESCRIPTION
- A Mu is almost identical to a `FunctionK`, so rather than a conversion we can just make it a subtype of `FunctionK`.
- We add a method to build an AlgebraM from a `FunctionK`.