### PR TITLE
Remove Wrapper Case Class

### DIFF
--- a/modules/core/src/main/scala/higherkindness/droste/data/Mu.scala
+++ b/modules/core/src/main/scala/higherkindness/droste/data/Mu.scala
@@ -25,7 +25,7 @@ object Mu {
     Algebra(fmf => Default(fmf))
 
   def coalgebra[F[_]: Functor]: Coalgebra[F, Mu[F]] =
-    Coalgebra[F, Mu[F]](mf => mf[F[Mu[F]]](Algebra(_ map algebra.run)))
+    Coalgebra[F, Mu[F]](mf => mf[F[Mu[F]]](Algebra(_ map algebra.apply)))
 
   def apply[F[_]: Functor](fmf: F[Mu[F]]): Mu[F] = algebra[F].apply(fmf)
   def un[F[_]: Functor](mf: Mu[F]): F[Mu[F]]     = coalgebra[F].apply(mf)

--- a/modules/core/src/main/scala/higherkindness/droste/data/Nu.scala
+++ b/modules/core/src/main/scala/higherkindness/droste/data/Nu.scala
@@ -24,7 +24,7 @@ object Nu {
     new Default(unfold0, a0)
 
   def algebra[F[_]: Functor]: Algebra[F, Nu[F]] =
-    Algebra(t => Nu(Coalgebra[F, F[Nu[F]]](_ map coalgebra.run), t))
+    Algebra(t => Nu(Coalgebra[F, F[Nu[F]]](_ map coalgebra.apply), t))
 
   def coalgebra[F[_]: Functor]: Coalgebra[F, Nu[F]] =
     Coalgebra(nf => nf.unfold(nf.a).map(Nu(nf.unfold, _)))

--- a/modules/core/src/main/scala/higherkindness/droste/data/stream.scala
+++ b/modules/core/src/main/scala/higherkindness/droste/data/stream.scala
@@ -28,10 +28,10 @@ object Stream extends StreamInstances {
   def empty[A]: Stream[A] = Nu(NilF: ListF[A, Nu[ListF[A, ?]]])
 
   def map[A, B](fa: Stream[A])(f: A => B): Stream[B] =
-    Nu(Coalgebra(fa.unfold.run andThen (_ match {
+    Nu(Coalgebra( (x: fa.A) => fa.unfold(x) match {
       case ConsF(head, tail) => ConsF(f(head), tail)
       case NilF              => NilF
-    })), fa.a)
+    }), fa.a)
 
   def flatMap[A, B](fa: Stream[A])(f: A => Stream[B]): Stream[B] = {
     type S = Either[fa.A, (Stream[B], fa.A)]

--- a/modules/core/src/main/scala/higherkindness/droste/scheme.scala
+++ b/modules/core/src/main/scala/higherkindness/droste/scheme.scala
@@ -87,11 +87,9 @@ private[droste] sealed trait SchemeConvenientPorcelain {
     )(implicit embed: EmbedP[F], ev: TraverseP[F]): A => M[PatR[F]] =
       scheme.anaM[M, PatF[F, ?], A, PatR[F]](coalgebraM)
 
-    def gana[F[_], A, S](
-        scattered: GCoalgebra.Scattered[PatF[F, ?], A, S]
+    def gana[F[_], A, S](scattered: GCoalgebra.Scattered[PatF[F, ?], A, S]
     )(implicit embed: EmbedP[F], ev: FunctorP[F]): A => PatR[F] =
-      scheme.gana[PatF[F, ?], A, S, PatR[F]](scattered.coalgebra)(
-        scattered.scatter)
+      scheme.gana[PatF[F, ?], A, S, PatR[F]](scattered)(scattered.scatter)
 
     def ganaM[M[_]: Monad, F[_], A, S](
         scattered: GCoalgebraM.Scattered[M, PatF[F, ?], A, S]

--- a/modules/core/src/main/scala/higherkindness/droste/scheme.scala
+++ b/modules/core/src/main/scala/higherkindness/droste/scheme.scala
@@ -42,22 +42,22 @@ private[droste] sealed trait SchemeConvenientPorcelain {
   def ana[F[_]: Functor, A, R](
       coalgebra: Coalgebra[F, A]
   )(implicit embed: Embed[F, R]): A => R =
-    kernel.hylo(embed.algebra.run, coalgebra.run)
+    kernel.hylo(embed.algebra.apply, coalgebra.apply)
 
   def anaM[M[_]: Monad, F[_]: Traverse, A, R](
       coalgebraM: CoalgebraM[M, F, A]
   )(implicit embed: Embed[F, R]): A => M[R] =
-    kernel.hyloM(embed.algebra.lift[M].run, coalgebraM.run)
+    kernel.hyloM(embed.algebra.lift[M].apply, coalgebraM.apply)
 
   def cata[F[_]: Functor, R, B](
       algebra: Algebra[F, B]
   )(implicit project: Project[F, R]): R => B =
-    kernel.hylo(algebra.run, project.coalgebra.run)
+    kernel.hylo(algebra.apply, project.coalgebra.apply)
 
   def cataM[M[_]: Monad, F[_]: Traverse, R, B](
       algebraM: AlgebraM[M, F, B]
   )(implicit project: Project[F, R]): R => M[B] =
-    kernel.hyloM(algebraM.run, project.coalgebra.lift[M].run)
+    kernel.hyloM(algebraM.apply, project.coalgebra.lift[M].apply)
 
   /** Convenience to specify the base constructor "shape" (such as `Fix`
     * or `Cofree[?[_], Int]`) for recursion.
@@ -176,7 +176,7 @@ private[droste] sealed trait SchemeGeneralizedPlumbing {
         coalgebra(a).map(
           kernel.hylo[F, SA, SB](
             fb => gather(algebra(fb), fb),
-            sa => scatter(sa).fold(coalgebra.run, identity))))
+            sa => scatter(sa).fold(coalgebra.apply, identity))))
 
   def ghyloM[M[_]: Monad, F[_]: Traverse, A, SA, SB, B](
       algebra: GAlgebraM[M, F, SB, B],
@@ -191,8 +191,8 @@ private[droste] sealed trait SchemeGeneralizedPlumbing {
             .traverse(
               kernel.hyloM[M, F, SA, SB](
                 fb => algebra(fb).map(gather(_, fb)),
-                sa => scatter(sa).fold(coalgebra.run, _.pure[M])))
-            .flatMap(algebra.run))
+                sa => scatter(sa).fold(coalgebra.apply, _.pure[M])))
+            .flatMap(algebra.apply))
 
   def gcata[F[_]: Functor, R, S, B](galgebra: GAlgebra[F, S, B])(
       gather: Gather[F, S, B]
@@ -204,7 +204,7 @@ private[droste] sealed trait SchemeGeneralizedPlumbing {
           .map(
             kernel.hylo[F, R, S](
               fb => gather(galgebra(fb), fb),
-              project.coalgebra.run)))
+              project.coalgebra.apply)))
 
   def gcataM[M[_]: Monad, F[_]: Traverse, R, S, B](
       algebra: GAlgebraM[M, F, S, B])(
@@ -217,8 +217,8 @@ private[droste] sealed trait SchemeGeneralizedPlumbing {
           kernel
             .hyloM[M, F, R, S](
               fb => algebra(fb).map(gather(_, fb)),
-              project.coalgebra.lift[M].run))
-        .flatMap(algebra.run)
+              project.coalgebra.lift[M].apply))
+        .flatMap(algebra.apply)
 
   def gana[F[_]: Functor, A, S, R](coalgebra: GCoalgebra[F, A, S])(
       scatter: Scatter[F, A, S]
@@ -227,8 +227,8 @@ private[droste] sealed trait SchemeGeneralizedPlumbing {
       embed.algebra(
         coalgebra(a).map(
           kernel.hylo[F, S, R](
-            embed.algebra.run,
-            s => scatter(s).fold(coalgebra.run, identity))))
+            embed.algebra.apply,
+            s => scatter(s).fold(coalgebra.apply, identity))))
 
   def ganaM[M[_]: Monad, F[_]: Traverse, A, S, R](
       coalgebra: GCoalgebraM[M, F, A, S])(
@@ -239,9 +239,9 @@ private[droste] sealed trait SchemeGeneralizedPlumbing {
         .flatMap(
           _.traverse(
             kernel.hyloM[M, F, S, R](
-              embed.algebra.lift[M].run,
-              sa => scatter(sa).fold(coalgebra.run, _.pure[M]))))
-        .map(embed.algebra.run)
+              embed.algebra.lift[M].apply,
+              sa => scatter(sa).fold(coalgebra.apply, _.pure[M]))))
+        .map(embed.algebra.apply)
 
 }
 
@@ -268,7 +268,7 @@ private[droste] sealed trait SchemeHyloPorcelain {
       algebra: Algebra[F, B],
       coalgebra: Coalgebra[F, A]
   ): A => B =
-    kernel.hylo(algebra.run, coalgebra.run)
+    kernel.hylo(algebra.apply, coalgebra.apply)
 
   /** Build a monadic hylomorphism
     *
@@ -296,6 +296,6 @@ private[droste] sealed trait SchemeHyloPorcelain {
       algebra: AlgebraM[M, F, B],
       coalgebra: CoalgebraM[M, F, A]
   ): A => M[B] =
-    kernel.hyloM(algebra.run, coalgebra.run)
+    kernel.hyloM(algebra.apply, coalgebra.apply)
 
 }

--- a/modules/core/src/main/scala/higherkindness/droste/trans.scala
+++ b/modules/core/src/main/scala/higherkindness/droste/trans.scala
@@ -3,32 +3,40 @@ package higherkindness.droste
 import cats.Functor
 import cats.syntax.functor._
 
-final class GTrans[F[_], G[_], A, B](val run: F[A] => G[B]) extends AnyVal {
+abstract class GTrans[F[_], G[_], A, B] { self =>
+  def apply(fa: F[A]): G[B]
+
   def algebra(implicit embed: Embed[G, B]): GAlgebra[F, A, B] =
-    GAlgebra(run andThen embed.algebra.run)
+    GAlgebra(x => embed.algebra(self(x)))
 
   def coalgebra(implicit project: Project[F, A]): GCoalgebra[G, A, B] =
-    GCoalgebra(project.coalgebra.run andThen run)
+    GCoalgebra(x => self(project.coalgebra(x)))
+
 }
 
 object GTrans {
   def apply[F[_], G[_], A, B](run: F[A] => G[B]): GTrans[F, G, A, B] =
-    new GTrans(run)
+    new GTrans[F, G, A, B] {
+      def apply(fa: F[A]): G[B] = run(fa)
+    }
 }
 
-final class GTransM[M[_], F[_], G[_], A, B](val run: F[A] => M[G[B]])
-    extends AnyVal {
+abstract class GTransM[M[_], F[_], G[_], A, B] { self =>
+  def apply(fa: F[A]): M[G[B]] 
+
   def algebra(
-      implicit embed: Embed[G, B],
-      ev: Functor[M]): GAlgebraM[M, F, A, B] =
-    GAlgebraM(run andThen (_.map(embed.algebra.run)))
+    implicit embed: Embed[G, B],
+    ev: Functor[M]): GAlgebraM[M, F, A, B] =
+    GAlgebraM(x => self(x).map(embed.algebra.apply))
 
   def coalgebra(implicit project: Project[F, A]): GCoalgebraM[M, G, A, B] =
-    GCoalgebraM(project.coalgebra.run andThen run)
+    GCoalgebraM(x => self(project.coalgebra(x)))
+
 }
 
 object GTransM {
-  def apply[M[_], F[_], G[_], A, B](
-      run: F[A] => M[G[B]]): GTransM[M, F, G, A, B] =
-    new GTransM(run)
+  def apply[M[_], F[_], G[_], A, B](run: F[A] => M[G[B]]) = 
+    new GTransM[M, F, G, A, B] {
+      def apply(fa: F[A]): M[G[B]] = run(fa)
+    }
 }

--- a/modules/core/src/main/scala/higherkindness/droste/trans.scala
+++ b/modules/core/src/main/scala/higherkindness/droste/trans.scala
@@ -27,7 +27,9 @@ abstract class GTransM[M[_], F[_], G[_], A, B] { self =>
   def algebra(
     implicit embed: Embed[G, B],
     ev: Functor[M]): GAlgebraM[M, F, A, B] =
-    GAlgebraM(x => self(x).map(embed.algebra.apply))
+    new GAlgebraM[M, F, A, B]{
+      def apply(x: F[A]): M[B] = self(x).map(embed.algebra.apply)
+    }
 
   def coalgebra(implicit project: Project[F, A]): GCoalgebraM[M, G, A, B] =
     GCoalgebraM(x => self(project.coalgebra(x)))

--- a/modules/macros/src/main/scala/higherkindness/droste/macros/impl/Macros.scala
+++ b/modules/macros/src/main/scala/higherkindness/droste/macros/impl/Macros.scala
@@ -351,7 +351,7 @@ object Macros {
 
       val algebra =
         q"""
-        new _root_.higherkindness.droste.GAlgebra[λ, ${clait.name}[..$claitTypeParamNames], ${clait.name}[..$claitTypeParamNames]]($mtch)
+        _root_.higherkindness.droste.GAlgebra[λ, ${clait.name}[..$claitTypeParamNames], ${clait.name}[..$claitTypeParamNames]]($mtch)
         """
 
       q"def embedAlgebra[..${clait.tparams}]: _root_.higherkindness.droste.Algebra[λ, ${clait.name}[..$claitTypeParamNames]] = $algebra"
@@ -380,7 +380,7 @@ object Macros {
 
       val algebra =
         q"""
-        new _root_.higherkindness.droste.GCoalgebra[λ, ${clait.name}[..$claitTypeParamNames], ${clait.name}[..$claitTypeParamNames]]($mtch)
+        _root_.higherkindness.droste.GCoalgebra[λ, ${clait.name}[..$claitTypeParamNames], ${clait.name}[..$claitTypeParamNames]]($mtch)
         """
 
       q"def projectCoalgebra[..${clait.tparams}]: _root_.higherkindness.droste.Coalgebra[λ, ${clait.name}[..$claitTypeParamNames]] = $algebra"

--- a/modules/tests/src/test/scala/higherkindness/droste/tests/AlgebraTests.scala
+++ b/modules/tests/src/test/scala/higherkindness/droste/tests/AlgebraTests.scala
@@ -19,12 +19,12 @@ final class AlgebraTests extends Properties("algebras") {
   implicit def galgebraEq[F[_], S, A](
       implicit FS: Arbitrary[F[S]],
       A: Eq[A]): Eq[GAlgebra[F, S, A]] =
-    Eq.by[GAlgebra[F, S, A], F[S] => A](_.run)
+    Eq.by[GAlgebra[F, S, A], F[S] => A](_.apply)
 
   implicit def gcoalgebraEq[F[_], A, S](
       implicit A: Arbitrary[A],
       FS: Eq[F[S]]): Eq[GCoalgebra[F, A, S]] =
-    Eq.by[GCoalgebra[F, A, S], A => F[S]](_.run)
+    Eq.by[GCoalgebra[F, A, S], A => F[S]](_.apply)
 
   implicit def arbitraryGAlgebra[F[_], S, A](
       implicit arbA: Arbitrary[A],


### PR DESCRIPTION
This commit simplifies the `GAlgebra` class of Droste. Instead of
being a final case class that wraps a `Function1` object, we change it
to just be an abstract class with an `apply` (or `run`) method.

Those using Scala 2.12 will benefit of  Single-Abstract-Method syntax,
to write most of the code without the `GAlgebra` constructor, like functions.