### PR TITLE
Add MiMa

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,10 +50,12 @@ def paradiseDep(scalaVersion: String): Seq[ModuleID] =
 
 lazy val meta = module("meta")
   .settings(
-    mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % V.drostePrev),
+    mimaPreviousArtifacts := Set(
+      organization.value %%% moduleName.value % V.drostePrev),
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect"  % scalaVersion.value,
-      "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided"))
+      "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided")
+  )
 
 lazy val metaJVM = meta.jvm
 lazy val metaJS  = meta.js
@@ -61,24 +63,33 @@ lazy val metaJS  = meta.js
 lazy val core = module("core")
   .dependsOn(meta)
   .settings(
-    mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % V.drostePrev),
+    mimaPreviousArtifacts := Set(
+      organization.value %%% moduleName.value % V.drostePrev),
     mimaBinaryIssueFilters ++= {
       import com.typesafe.tools.mima.core.IncompatibleSignatureProblem
       import com.typesafe.tools.mima.core.ProblemFilters.exclude
       // See https://github.com/lightbend/mima/issues/423
       Seq(
-        exclude[IncompatibleSignatureProblem]("higherkindness.droste.Basis#Default.unapply"),
-        exclude[IncompatibleSignatureProblem]("higherkindness.droste.GAlgebra#Gathered.unapply"),
-        exclude[IncompatibleSignatureProblem]("higherkindness.droste.GAlgebraArrow.algebra"),
-        exclude[IncompatibleSignatureProblem]("higherkindness.droste.GAlgebraM#Gathered.unapply"),
-        exclude[IncompatibleSignatureProblem]("higherkindness.droste.GCoalgebra#Scattered.unapply"),
-        exclude[IncompatibleSignatureProblem]("higherkindness.droste.GCoalgebraArrow.algebra"),
-        exclude[IncompatibleSignatureProblem]("higherkindness.droste.GCoalgebraM#Scattered.unapply")
+        exclude[IncompatibleSignatureProblem](
+          "higherkindness.droste.Basis#Default.unapply"),
+        exclude[IncompatibleSignatureProblem](
+          "higherkindness.droste.GAlgebra#Gathered.unapply"),
+        exclude[IncompatibleSignatureProblem](
+          "higherkindness.droste.GAlgebraArrow.algebra"),
+        exclude[IncompatibleSignatureProblem](
+          "higherkindness.droste.GAlgebraM#Gathered.unapply"),
+        exclude[IncompatibleSignatureProblem](
+          "higherkindness.droste.GCoalgebra#Scattered.unapply"),
+        exclude[IncompatibleSignatureProblem](
+          "higherkindness.droste.GCoalgebraArrow.algebra"),
+        exclude[IncompatibleSignatureProblem](
+          "higherkindness.droste.GCoalgebraM#Scattered.unapply")
       )
     },
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-core" % V.cats,
-      "org.typelevel" %%% "cats-free" % V.cats))
+      "org.typelevel" %%% "cats-free" % V.cats)
+  )
 
 lazy val coreJVM = core.jvm
 lazy val coreJS  = core.js
@@ -86,7 +97,8 @@ lazy val coreJS  = core.js
 lazy val macros = module("macros")
   .dependsOn(core)
   .settings(
-    mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % V.drostePrev),
+    mimaPreviousArtifacts := Set(
+      organization.value %%% moduleName.value % V.drostePrev),
     libraryDependencies ++= paradiseDep(scalaVersion.value))
 
 lazy val macrosJVM = macros.jvm
@@ -96,8 +108,9 @@ lazy val reftree = module("reftree")
   .dependsOn(core)
   .settings(noScala213Settings)
   .settings(
-    mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % V.drostePrev),
-    libraryDependencies ++= Seq("io.github.stanch" %%% "reftree" % "1.2.1"))
+    mimaPreviousArtifacts := Set(
+      organization.value                           %%% moduleName.value % V.drostePrev),
+    libraryDependencies ++= Seq("io.github.stanch" %%% "reftree"        % "1.2.1"))
 
 lazy val reftreeJVM = reftree.jvm
 lazy val reftreeJS  = reftree.js
@@ -105,9 +118,11 @@ lazy val reftreeJS  = reftree.js
 lazy val scalacheck = module("scalacheck")
   .dependsOn(core)
   .settings(
-    mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % V.drostePrev),
+    mimaPreviousArtifacts := Set(
+      organization.value %%% moduleName.value % V.drostePrev),
     libraryDependencies ++= Seq(
-      "org.scalacheck" %%% "scalacheck" % V.scalacheck))
+      "org.scalacheck" %%% "scalacheck" % V.scalacheck)
+  )
 
 lazy val scalacheckJVM = scalacheck.jvm
 lazy val scalacheckJS  = scalacheck.js
@@ -115,8 +130,11 @@ lazy val scalacheckJS  = scalacheck.js
 lazy val laws = module("laws")
   .dependsOn(core)
   .settings(
-    mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % V.drostePrev),
-    libraryDependencies ++= Seq("org.scalacheck" %%% "scalacheck" % V.scalacheck))
+    mimaPreviousArtifacts := Set(
+      organization.value %%% moduleName.value % V.drostePrev),
+    libraryDependencies ++= Seq(
+      "org.scalacheck" %%% "scalacheck" % V.scalacheck)
+  )
 
 lazy val lawsJVM = laws.jvm
 lazy val lawsJS  = laws.js
@@ -125,13 +143,12 @@ lazy val tests = module("tests")
   .dependsOn(core, scalacheck, laws, macros)
   .settings(noPublishSettings)
   .disablePlugins(MimaPlugin)
-  .settings(
-    libraryDependencies ++= Seq(
-      "org.scalacheck" %%% "scalacheck"         % V.scalacheck,
-      "org.typelevel"  %%% "cats-laws"          % V.cats,
-      "eu.timepit"     %%% "refined"            % V.refined,
-      "eu.timepit"     %%% "refined-scalacheck" % V.refined
-    ) ++ paradiseDep(scalaVersion.value))
+  .settings(libraryDependencies ++= Seq(
+    "org.scalacheck" %%% "scalacheck"         % V.scalacheck,
+    "org.typelevel"  %%% "cats-laws"          % V.cats,
+    "eu.timepit"     %%% "refined"            % V.refined,
+    "eu.timepit"     %%% "refined-scalacheck" % V.refined
+  ) ++ paradiseDep(scalaVersion.value))
 
 lazy val testsJVM = tests.jvm
 lazy val testsJS  = tests.js

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ lazy val root = (project in file("."))
 
 lazy val publish = (project in file("."))
   .settings(noPublishSettings)
+  .disablePlugins(MimaPlugin)
   .aggregate(coreJVM, coreJS)
   .aggregate(metaJVM, metaJS)
   .aggregate(macrosJVM, macrosJS)
@@ -35,6 +36,7 @@ lazy val V = new {
   val algebra    = "2.0.0"
   val atto       = "0.7.1"
   val scalacheck = "1.14.2"
+  val drostePrev = "0.7.0"
 }
 
 def paradiseDep(scalaVersion: String): Seq[ModuleID] =
@@ -48,6 +50,7 @@ def paradiseDep(scalaVersion: String): Seq[ModuleID] =
 
 lazy val meta = module("meta")
   .settings(
+    mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % V.drostePrev),
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect"  % scalaVersion.value,
       "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided"))
@@ -58,6 +61,21 @@ lazy val metaJS  = meta.js
 lazy val core = module("core")
   .dependsOn(meta)
   .settings(
+    mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % V.drostePrev),
+    mimaBinaryIssueFilters ++= {
+      import com.typesafe.tools.mima.core.IncompatibleSignatureProblem
+      import com.typesafe.tools.mima.core.ProblemFilters.exclude
+      // See https://github.com/lightbend/mima/issues/423
+      Seq(
+        exclude[IncompatibleSignatureProblem]("higherkindness.droste.Basis#Default.unapply"),
+        exclude[IncompatibleSignatureProblem]("higherkindness.droste.GAlgebra#Gathered.unapply"),
+        exclude[IncompatibleSignatureProblem]("higherkindness.droste.GAlgebraArrow.algebra"),
+        exclude[IncompatibleSignatureProblem]("higherkindness.droste.GAlgebraM#Gathered.unapply"),
+        exclude[IncompatibleSignatureProblem]("higherkindness.droste.GCoalgebra#Scattered.unapply"),
+        exclude[IncompatibleSignatureProblem]("higherkindness.droste.GCoalgebraArrow.algebra"),
+        exclude[IncompatibleSignatureProblem]("higherkindness.droste.GCoalgebraM#Scattered.unapply")
+      )
+    },
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-core" % V.cats,
       "org.typelevel" %%% "cats-free" % V.cats))
@@ -67,7 +85,9 @@ lazy val coreJS  = core.js
 
 lazy val macros = module("macros")
   .dependsOn(core)
-  .settings(libraryDependencies ++= paradiseDep(scalaVersion.value))
+  .settings(
+    mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % V.drostePrev),
+    libraryDependencies ++= paradiseDep(scalaVersion.value))
 
 lazy val macrosJVM = macros.jvm
 lazy val macrosJS  = macros.js
@@ -76,6 +96,7 @@ lazy val reftree = module("reftree")
   .dependsOn(core)
   .settings(noScala213Settings)
   .settings(
+    mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % V.drostePrev),
     libraryDependencies ++= Seq("io.github.stanch" %%% "reftree" % "1.2.1"))
 
 lazy val reftreeJVM = reftree.jvm
@@ -83,16 +104,19 @@ lazy val reftreeJS  = reftree.js
 
 lazy val scalacheck = module("scalacheck")
   .dependsOn(core)
-  .settings(libraryDependencies ++= Seq(
-    "org.scalacheck" %%% "scalacheck" % V.scalacheck))
+  .settings(
+    mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % V.drostePrev),
+    libraryDependencies ++= Seq(
+      "org.scalacheck" %%% "scalacheck" % V.scalacheck))
 
 lazy val scalacheckJVM = scalacheck.jvm
 lazy val scalacheckJS  = scalacheck.js
 
 lazy val laws = module("laws")
   .dependsOn(core)
-  .settings(libraryDependencies ++= Seq(
-    "org.scalacheck" %%% "scalacheck" % V.scalacheck))
+  .settings(
+    mimaPreviousArtifacts := Set(organization.value %%% moduleName.value % V.drostePrev),
+    libraryDependencies ++= Seq("org.scalacheck" %%% "scalacheck" % V.scalacheck))
 
 lazy val lawsJVM = laws.jvm
 lazy val lawsJS  = laws.js
@@ -100,12 +124,14 @@ lazy val lawsJS  = laws.js
 lazy val tests = module("tests")
   .dependsOn(core, scalacheck, laws, macros)
   .settings(noPublishSettings)
-  .settings(libraryDependencies ++= Seq(
-    "org.scalacheck" %%% "scalacheck"         % V.scalacheck,
-    "org.typelevel"  %%% "cats-laws"          % V.cats,
-    "eu.timepit"     %%% "refined"            % V.refined,
-    "eu.timepit"     %%% "refined-scalacheck" % V.refined
-  ) ++ paradiseDep(scalaVersion.value))
+  .disablePlugins(MimaPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.scalacheck" %%% "scalacheck"         % V.scalacheck,
+      "org.typelevel"  %%% "cats-laws"          % V.cats,
+      "eu.timepit"     %%% "refined"            % V.refined,
+      "eu.timepit"     %%% "refined-scalacheck" % V.refined
+    ) ++ paradiseDep(scalaVersion.value))
 
 lazy val testsJVM = tests.jvm
 lazy val testsJS  = tests.js
@@ -114,6 +140,7 @@ lazy val athema = module("athema", prefix = "")
   .dependsOn(core)
   .settings(noPublishSettings)
   .settings(noScala213Settings)
+  .disablePlugins(MimaPlugin)
   .settings(
     libraryDependencies ++=
       Seq(
@@ -132,6 +159,7 @@ lazy val readme = (project in file("modules/readme"))
   .dependsOn(coreJVM)
   .dependsOn(athemaJVM)
   .settings(noPublishSettings)
+  .disablePlugins(MimaPlugin)
   .settings(
     scalacOptions in Tut ~= {
       _.filterNot(
@@ -152,6 +180,7 @@ lazy val docs = (project in file("docs"))
   .settings(noPublishSettings: _*)
   .enablePlugins(MicrositesPlugin)
   .disablePlugins(ProjectPlugin)
+  .disablePlugins(MimaPlugin)
   .settings(
     scalacOptions in Tut ~= (_ filterNot Set("-Ywarn-unused-import", "-Xlint").contains)
   )

--- a/modules/tests/src/test/scala/higherkindness/droste/tests/ListTests.scala
+++ b/modules/tests/src/test/scala/higherkindness/droste/tests/ListTests.scala
@@ -58,7 +58,7 @@ final class ListTests extends Properties("ListTest") {
       toList(x)
     }
   implicit def arbitrary[T](implicit T: Basis[ListF[Int, ?], T]): Arbitrary[T] =
-    Arbitrary(Gen.resize(50, Gen.listOf(Gen.chooseNum[Int](1, Int.MaxValue))).map(scheme.ana(ListF.fromScalaListCoalgebra[Int])))
+    Arbitrary(Gen.resize(25, Gen.listOf(Gen.chooseNum[Int](1, Int.MaxValue))).map(scheme.ana(ListF.fromScalaListCoalgebra[Int])))
 
   import ListF._
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,8 @@
+resolvers += Resolver.url(
+  "typesafe sbt-plugins",
+  url("https://dl.bintray.com/typesafe/sbt-plugins")
+)(Resolver.ivyStylePatterns)
+
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.6.1")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.1")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "0.6.29")
@@ -6,3 +11,4 @@ addSbtPlugin("org.scoverage"      % "sbt-scoverage"                 % "1.6.0")
 addSbtPlugin("io.crashbox"        % "sbt-gpg"                       % "0.2.0")
 addSbtPlugin("com.github.gseitz"  % "sbt-release"                   % "1.0.12")
 addSbtPlugin("com.47deg"          % "sbt-microsites"                % "0.9.7")
+addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"               % "0.6.1")


### PR DESCRIPTION
Put this together to verify that the current master could be published as 0.7.1. The exclusions are needed because of [a MiMa bug](https://github.com/lightbend/mima/issues/423) I reported yesterday.

Because the project is pre-1.0 I haven't added the bincompat checking to the build, but you can confirm it manually like this:

```
sbt ++2.11.12 mimaReportBinaryIssues
sbt ++2.12.10 mimaReportBinaryIssues
```