### PR TITLE
remove all usecase scaladoc tags, which crash sbt and prevent publishing

### DIFF
--- a/modules/core/src/main/scala/higherkindness/droste/kernel.scala
+++ b/modules/core/src/main/scala/higherkindness/droste/kernel.scala
@@ -34,9 +34,6 @@ object kernel {
     * </pre>
     *
     * @group refolds
-    *
-    * @usecase def hylo[F[_], A, B](algebra: F[B] => B, coalgebra: A => F[A]): A => B
-    *   @inheritdoc
     */
   def hylo[F[_]: Functor, A, B](
       algebra: F[B] => B,
@@ -52,9 +49,6 @@ object kernel {
     * to `hylo` with the types set properly.
     *
     * @group refolds
-    *
-    * @usecase def hyloC[F[_], G[_], A, B](algebra: F[G[B]] => B, coalgebra: A => F[G[A]]): A => B
-    *   @inheritdoc
     */
   @inline def hyloC[F[_]: Functor, G[_]: Functor, A, B](
       algebra: F[G[B]] => B,
@@ -82,9 +76,6 @@ object kernel {
     * </pre>
     *
     * @group refolds
-    *
-    * @usecase def hyloM[M[_], F[_], A, B](algebra: F[B] => M[B], coalgebra: A => M[F[A]]): A => M[B]
-    *   @inheritdoc
     */
   def hyloM[M[_]: Monad, F[_]: Traverse, A, B](
       algebra: F[B] => M[B],
@@ -95,9 +86,6 @@ object kernel {
   /** Convenience to build a monadic hylomorphism for the composed functor `F[G[_]]`.
     *
     * @group refolds
-    *
-    * @usecase def hyloMC[M[_], F[_], G[_], A, B](algebra: F[G[B]] => M[B], coalgebra: A => M[F[G[A]]]): A => M[B]
-    *   @inheritdoc
     */
   def hyloMC[M[_]: Monad, F[_]: Traverse, G[_]: Traverse, A, B](
       algebra: F[G[B]] => M[B],

--- a/modules/core/src/main/scala/higherkindness/droste/scheme.scala
+++ b/modules/core/src/main/scala/higherkindness/droste/scheme.scala
@@ -65,9 +65,6 @@ private[droste] sealed trait SchemeConvenientPorcelain {
     * This helps to guide Scala's type inference so all of the type
     * parameters for the various recursion scheme methods don't have
     * to be provided.
-    *
-    * @usecase def apply[Shape]: SchemePartialBasis[Shape, Shape]
-    *   @inheritdoc
     */
   def apply[PatR[_[_]]](
       implicit ev: Basis.Solve[PatR]): SchemePartialBasis[PatR, ev.PatF] =
@@ -266,9 +263,6 @@ private[droste] sealed trait SchemeHyloPorcelain {
     * </pre>
     *
     * @group refolds
-    *
-    * @usecase def hylo[F[_], A, B](algebra: Algebra[F, B], coalgebra: Coalgebra[F, A]): A => B
-    *   @inheritdoc
     */
   def hylo[F[_]: Functor, A, B](
       algebra: Algebra[F, B],
@@ -297,9 +291,6 @@ private[droste] sealed trait SchemeHyloPorcelain {
     * </pre>
     *
     * @group refolds
-    *
-    * @usecase def hyloM[M[_], F[_], A, B](algebra: AlgebraM[M, F, B], coalgebra: CoalgebraM[M, F, A]): A => M[B]
-    *   @inheritdoc
     */
   def hyloM[M[_]: Monad, F[_]: Traverse, A, B](
       algebra: AlgebraM[M, F, B],

--- a/modules/core/src/main/scala/higherkindness/droste/zoo.scala
+++ b/modules/core/src/main/scala/higherkindness/droste/zoo.scala
@@ -22,9 +22,6 @@ private[droste] trait Zoo {
     * unfold.
     *
     * @group unfolds
-    *
-    * @usecase def apo[F[_], A, R](coalgebra: RCoalgebra[R, F, A]): A => R
-    *   @inheritdoc
     */
   def apo[F[_]: Functor, A, R](
       coalgebra: RCoalgebra[R, F, A]
@@ -36,9 +33,6 @@ private[droste] trait Zoo {
   /** A monadic version of an apomorphism.
     *
     * @group unfolds
-    *
-    * @usecase def apoM[M[_], F[_], A, R](coalgebraM: RCoalgebraM[R, M, F, A]): A => M[R]
-    *   @inheritdoc
     */
   def apoM[M[_]: Monad, F[_]: Traverse, A, R](
       coalgebraM: RCoalgebraM[R, M, F, A]
@@ -59,9 +53,6 @@ private[droste] trait Zoo {
     * value as well as the original value.
     *
     * @group folds
-    *
-    * @usecase def para[F[_], R, B](algebra: RAlgebra[R, F, B]): R => B
-    *   @inheritdoc
     */
   def para[F[_]: Functor, R, B](
       algebra: RAlgebra[R, F, B]
@@ -71,9 +62,6 @@ private[droste] trait Zoo {
   /** A monadic version of a paramorphism.
     *
     * @group folds
-    *
-    * @usecase def paraM[M[_], F[_], R, B](algebraM: RAlgebraM[R, M, F, B]): R => M[B]
-    *   @inheritdoc
     */
   def paraM[M[_]: Monad, F[_]: Traverse, R, B](
       algebraM: RAlgebraM[R, M, F, B]
@@ -85,9 +73,6 @@ private[droste] trait Zoo {
   /** Histomorphism
     *
     * @group folds
-    *
-    * @usecase def histo[F[_], R, B](algebra: CVAlgebra[F, B]): R => B
-    *   @inheritdoc
     */
   def histo[F[_]: Functor, R, B](
       algebra: CVAlgebra[F, B]
@@ -100,9 +85,6 @@ private[droste] trait Zoo {
   /** Futumorphism
     *
     * @group unfolds
-    *
-    * @usecase def futu[F[_], A, R](coalgebra: CVCoalgebra[F, A]): A => R
-    *   @inheritdoc
     */
   def futu[F[_]: Functor, A, R](
       coalgebra: CVCoalgebra[F, A]
@@ -115,9 +97,6 @@ private[droste] trait Zoo {
   /** A fusion refold of a futumorphism followed by a histomorphism
     *
     * @group refolds
-    *
-    * @usecase def chrono[F[_], A, B](algebra: CVAlgebra[F, B], coalgebra: CVCoalgebra[F, A]): A => B
-    *   @inheritdoc
     */
   def chrono[F[_]: Functor, A, B](
       algebra: CVAlgebra[F, B],
@@ -131,9 +110,6 @@ private[droste] trait Zoo {
   /** A fusion refold of an anamorphism followed by a histomorphism
     *
     * @group refolds
-    *
-    * @usecase def dyna[F[_], A, B](algebra: CVAlgebra[F, B], coalgebra: Coalgebra[F, A]): A => B
-    *   @inheritdoc
     */
   def dyna[F[_]: Functor, A, B](
       algebra: CVAlgebra[F, B],
@@ -149,9 +125,6 @@ private[droste] trait Zoo {
     * This allows one to preprocess the input structure.
     *
     * @group folds
-    *
-    * @usecase def prepro[F[_], R, B](natTrans: F ~> F, algebra: Algebra[F, B]): R => B
-    *   @inheritdoc
     */
   def prepro[F[_]: Functor, R, B](
       natTrans: F ~> F,
@@ -167,9 +140,6 @@ private[droste] trait Zoo {
     * This allows one to postprocess the output structure.
     *
     * @group unfolds
-    *
-    * @usecase def postpro[F[_], A, R](coalgebra: Coalgebra[F, A], natTrans: F ~> F): A => R
-    *   @inheritdoc
     */
   def postpro[F[_]: Functor, A, R](
       coalgebra: Coalgebra[F, A],
@@ -185,9 +155,6 @@ private[droste] trait Zoo {
     * This allows the second algebra to depend on the result of the first one.
     *
     * @group folds
-    *
-    * @usecase def zygo[F[_], R, A, B](algebra: Algebra[F, A], ralgebra: RAlgebra[A, F, B]): R => B
-    *   @inheritdoc
     */
   def zygo[F[_]: Functor, R, A, B](
       algebra: Algebra[F, A],


### PR DESCRIPTION
Removes `@usecase` scaladoc tags, which crash SBT during publish.

See https://github.com/scala/bug/issues/11572 and https://github.com/sbt/sbt/issues/4665 for some more context.