### PR TITLE
Modernize the Travis caching logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,8 @@ before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
   - rm -rf $HOME/.ivy2/local
-  - |
-    if [ ! "$(ls -A $HOME/nix-cache)" ]; then
-      cp -a /nix/* $HOME/nix-cache
-    fi
+  - mkdir -p $HOME/nix-cache
+  - nix copy --to file://$HOME/nix-cache -f default.nix buildInputs
 
 cache:
   directories:
@@ -51,11 +49,9 @@ cache:
     - $HOME/.coursier
     - $HOME/nix-cache
 
+# The Nix parts of this of this were adapted from https://nixos.wiki/wiki/Nix_on_Travis
 before_install:
   - git fetch --tags
-
-install: |
-  if [ "$(ls -A $HOME/nix-cache)" ]; then
-    sudo rm -rf /nix/*
-    cp -a $HOME/nix-cache/* /nix
-  fi
+  - sudo mkdir -p /etc/nix
+  - echo "substituters = https://cache.nixos.org/ file://$HOME/nix-cache" | sudo tee -a /etc/nix/nix.conf > /dev/null
+  - echo 'require-sigs = false' | sudo tee -a /etc/nix/nix.conf > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ cache:
     - $HOME/.sbt/boot/scala*
     - $HOME/.sbt/launchers
     - $HOME/.ivy2/cache
-    - $HOME/.coursier
+    - $HOME/.cache/coursier
     - $HOME/nix-cache
 
 # The Nix parts of this of this were adapted from https://nixos.wiki/wiki/Nix_on_Travis


### PR DESCRIPTION
Some time ago I copied Droste's .travis.yml for my build, so I thought
that I might be able to return the favor by updating it.

This PR does 2 things.

## update coursier cache location

The `~/.coursier` cache location is deprecated, and `~/.cache/coursier`
is the default for Linux builds.

## change Nix caching strategy

I've adapted the build to use the current suggestions in the [Nix docs](https://nixos.wiki/wiki/Nix_on_Travis)
for caching on Travis CI. Now instead of copying the entire Nix store
into the home directory, it just copies the `buildInputs` from
`default.nix`. It also sets up `~/nix-cache` as a substitute for
`cache.nixos.org` so that items in this cache can be found.

Note: I used droste's existing convention of `nix-cache` instead of
`nix.store` which is used in the Nix docs.

## other notes

The first build or two after these changes might be a bit slower
since parts of the cache will need to be rebuilt.