### PR TITLE
Proposal: drop scala 2.11, upgrade scalajs to 1.1.1, cats to 2.2.0-M1, refined to 0.9.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,8 @@ lazy val coverage = (project in file(".coverage"))
   .aggregate(testsJVM)
 
 lazy val V = new {
-  val cats       = "2.0.0"
-  val refined    = "0.9.12"
+  val cats       = "2.2.0-RC1"
+  val refined    = "0.9.15"
   val algebra    = "2.0.0"
   val atto       = "0.7.1"
   val scalacheck = "1.14.3"

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -72,7 +72,7 @@ object ProjectPlugin extends AutoPlugin {
       outputStrategy := Some(StdoutOutput),
       connectInput in run := true,
       cancelable in Global := true,
-      crossScalaVersions := List("2.11.12", "2.12.10", "2.13.1"),
+      crossScalaVersions := List("2.12.10", "2.13.1"),
       scalaVersion := "2.12.10"
     ) ++ publishSettings
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.url(
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "0.6.32")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.1.1")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.9")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"                 % "1.6.1")
 addSbtPlugin("io.crashbox"        % "sbt-gpg"                       % "0.2.1")


### PR DESCRIPTION
Fixes #164 

I'm currently using droste for work and we want to move forwards with the ecosystem to sjs 1.x, especially given that cats and cats-effect have dropped the support for sjs 0.6.x, and cats isn't published for 2.11 anymore.