### PR TITLE
Set publish project directory to .publish

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file("."))
   .aggregate(athemaJVM, athemaJS)
   .aggregate(readme)
 
-lazy val publish = (project in file("."))
+lazy val publish = (project in file(".publish"))
   .settings(noPublishSettings)
   .disablePlugins(MimaPlugin)
   .aggregate(coreJVM, coreJS)


### PR DESCRIPTION
It is undefined behavior in sbt to have multiple projects that have the
same path. Both the root and publish projects have were defined to be in
the base directory (file(".")). With older versions of sbt, only the
publish project would appear when running the `projects` command. With
sbt 1.4.0-M2, only root appears when running the `projects` command.
After applying this change, both root and publish appear.