### PR TITLE
Bump algebra and atto to versions with scala.js 1.0 releases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,8 +33,8 @@ lazy val coverage = (project in file(".coverage"))
 lazy val V = new {
   val cats       = "2.2.0-RC1"
   val refined    = "0.9.15"
-  val algebra    = "2.0.0"
-  val atto       = "0.7.1"
+  val algebra    = "2.0.1"
+  val atto       = "0.8.0"
   val scalacheck = "1.14.3"
   val drostePrev = "0.7.0"
 }


### PR DESCRIPTION
Currently in master `sbt athemaJS/update` will fail because the specified versions of its `algebra` and `atto` dependencies have not been published for Scala.js 1.x.

This was not caught until now because of the problem pointed out in #180: currently sbt's default project is set to `publish`, not the root project. The `publish` project does not aggregate the `athemaJVM` and `athemaJS` projects, so they are not checked by the CI build.

Questions for someone more familiar with the project (@pepegar? @andyscott?):
* should the `publish` project aggregate the athema projects? or are they deliberately excluded?
* what even is the `publish` project? I assume it's an aggregate of all the projects we want to publish, but how is it used? could we simplify the build by getting rid of it and setting `publish := false` on any projects we don't want to publish?