### PR TITLE
Add missing ci-publish sbt alias

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -251,5 +251,6 @@ addCommandAlias(
   ";+clean;+test"
 )
 addCommandAlias("ci-docs", ";github;mdoc")
+addCommandAlias("ci-publish", "github; ci-release")
 
 ThisBuild / resolvers += Resolver.sonatypeRepo("public")


### PR DESCRIPTION
CI-based releases are failing; I think this is just an oversight