### PR TITLE
Brings back the COPYING file as COPYING_NOTICE

### DIFF
--- a/COPYING_NOTICE
+++ b/COPYING_NOTICE
@@ -1,0 +1,20 @@
+Copyright 2018 Andy Scott
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+------
+
+Code in Droste has been influenced and inspired by other libraries in
+the Scala and Haskell communities (Matryoshka and Pointless Haskell,
+at the very least). Attribution to the respective projects will be
+improved if/when/as the Droste library matures.


### PR DESCRIPTION
Apparently, the Github API file fails to detecting the license. [LICENSE.md](https://github.com/higherkindness/droste/blob/main/LICENSE.md) contains the right one.