### PR TITLE
Updates dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,12 +20,12 @@ lazy val coverage = (project in file(".coverage"))
   .aggregate(testsJVM)
 
 lazy val V = new {
-  val cats             = "2.9.0"
+  val cats             = "2.13.0"
   val collectionCompat = "2.13.0"
-  val refined          = "0.10.3"
-  val algebra          = "2.9.0"
+  val refined          = "0.11.3"
+  val algebra          = "2.13.0"
   val atto             = "0.9.5"
-  val scalacheck       = "1.17.0"
+  val scalacheck       = "1.18.1"
   val drostePrev       = "0.9.0-M3"
 }
 

--- a/modules/scalacheck/src/main/scala/org/scalacheck/donotimport/Compat.scala
+++ b/modules/scalacheck/src/main/scala/org/scalacheck/donotimport/Compat.scala
@@ -20,8 +20,8 @@ object Compat {
       val re       = fn(a, seed)
       val nextLabs = labs | re.labels
       re.retrieve match {
-        case None           => r(None, re.seed).copy(l = nextLabs)
-        case Some(Right(b)) => r(Some(b), re.seed).copy(l = nextLabs)
+        case None           => r(None, re.seed).withLabels(nextLabs)
+        case Some(Right(b)) => r(Some(b), re.seed).withLabels(nextLabs)
         case Some(Left(a))  => tailRecMR(a, re.seed, nextLabs)(fn)
       }
     }


### PR DESCRIPTION
This PR updates some dependencies, which includes a change to the `modules/scalacheck/src/main/scala/org/scalacheck/donotimport/Compat.scala` file, to make it compatible with scalacheck 1.18.x.